### PR TITLE
'VSWhere.cmake' and 'NuGet.cmake' should do no work by default

### DIFF
--- a/VSWhere.cmake
+++ b/VSWhere.cmake
@@ -25,36 +25,57 @@ include_guard()
 
 include("${CMAKE_CURRENT_LIST_DIR}/ToolchainCommon.cmake")
 
-set(_ProgramFiles "ProgramFiles(x86)")
-find_program(VSWHERE_PATH
-    NAMES vswhere vswhere.exe
-    HINTS "$ENV{${_ProgramFiles}}/Microsoft Visual Studio/Installer"
-)
+#[[====================================================================================================================
+    toolchain_ensure_vswhere
+    ------------------------
 
-# If vswhere isn't found, download it.
-#
-# vswhere.exe will be downloaded to `TOOLCHAIN_TOOLS_PATH`. If `TOOLCHAIN_TOOLS_PATH` is not set then it will be downloaded to '${CMAKE_BINARY_DIR}/__tools'.
-if(VSWHERE_PATH STREQUAL "VSWHERE_PATH-NOTFOUND")
-    if(NOT VSWHERE_VERSION)
-        set(VSWHERE_VERSION "2.8.4")
-        set(VSWHERE_HASH "SHA256=E50A14767C27477F634A4C19709D35C27A72F541FB2BA5C3A446C80998A86419")
-    else()
-        if(NOT VSWHERE_HASH)
-            message(FATAL_ERROR "VSWHERE_VERSION is set to ${VSWHERE_VERSION}. VSWHERE_HASH must be set if VSWHERE_VERSION is set.")
-        endif()
-    endif()
+    Ensures that 'vswhere' is available and the VSWHERE_PATH variables is set in the cache. The following steps will be
+    taken:
 
-    if(NOT TOOLCHAIN_TOOLS_PATH)
-        set(TOOLCHAIN_TOOLS_PATH "${CMAKE_BINARY_DIR}/__tools")
-    endif()
+        1. If `VSWHERE_PATH` is set, then that value will be used.
+        2. If 'vswhere' is found through `find_program`, that path will be used.
+        3. 'vswhere' will be downloaded - specified by `VSWHERE_VERSION` and `VSWHERE_HASH` - into the
+           `TOOLCHAIN_TOOLS_PATH` and `VSWHERE_PATH` will be set to the download location. If `TOOLCHAIN_TOOLS_PATH` is
+           not set, then it will default to `${CMAKE_BINARY_DIR}/__tools`.
 
-    set(VSWHERE_PATH "${TOOLCHAIN_TOOLS_PATH}/vswhere.exe")
-    toolchain_download_file(
-        URL "https://github.com/microsoft/vswhere/releases/download/${VSWHERE_VERSION}/vswhere.exe"
-        PATH ${VSWHERE_PATH}
-        EXPECTED_HASH ${VSWHERE_HASH}
+    Note: Since `CMAKE_BINARY_DIR` is platform specific, the default download location will change by platform,
+    resulting in the tool being downloaded once for each platform that is built. Setting
+    `TOOLCHAIN_TOOLS_PATH` to a platform-independent path (e.g. relative to the root of the repository) will
+    allow 'vswhere' to be downloaded once for all platforms.
+====================================================================================================================]]#
+function(toolchain_ensure_vswhere)
+    set(_ProgramFiles "ProgramFiles(x86)")
+    find_program(VSWHERE_PATH
+        NAMES vswhere vswhere.exe
+        HINTS "$ENV{${_ProgramFiles}}/Microsoft Visual Studio/Installer"
     )
-endif()
+
+    # If vswhere isn't found, download it.
+    #
+    # vswhere.exe will be downloaded to `TOOLCHAIN_TOOLS_PATH`. If `TOOLCHAIN_TOOLS_PATH` is not set then it will be downloaded to '${CMAKE_BINARY_DIR}/__tools'.
+    if(VSWHERE_PATH STREQUAL "VSWHERE_PATH-NOTFOUND")
+        if(NOT VSWHERE_VERSION)
+            set(VSWHERE_VERSION "2.8.4")
+            set(VSWHERE_HASH "SHA256=E50A14767C27477F634A4C19709D35C27A72F541FB2BA5C3A446C80998A86419")
+        else()
+            if(NOT VSWHERE_HASH)
+                message(FATAL_ERROR "VSWHERE_VERSION is set to ${VSWHERE_VERSION}. VSWHERE_HASH must be set if VSWHERE_VERSION is set.")
+            endif()
+        endif()
+
+        if(NOT TOOLCHAIN_TOOLS_PATH)
+            set(TOOLCHAIN_TOOLS_PATH "${CMAKE_BINARY_DIR}/__tools")
+        endif()
+
+        set(VSWHERE_PATH "${TOOLCHAIN_TOOLS_PATH}/vswhere.exe" CACHE FILEPATH "The location of 'vswhere.exe'" FORCE)
+
+        toolchain_download_file(
+            URL "https://github.com/microsoft/vswhere/releases/download/${VSWHERE_VERSION}/vswhere.exe"
+            PATH ${VSWHERE_PATH}
+            EXPECTED_HASH ${VSWHERE_HASH}
+        )
+    endif()
+endfunction()
 
 #[[====================================================================================================================
     findVisualStudio
@@ -77,6 +98,8 @@ function(findVisualStudio)
     set(MULTI_VALUE_KEYWORDS REQUIRES PROPERTIES)
 
     cmake_parse_arguments(PARSE_ARGV 0 FIND_VS "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    toolchain_ensure_vswhere()
 
     set(VSWHERE_COMMAND ${VSWHERE_PATH} -latest)
 


### PR DESCRIPTION
As called out in #18 and #44, `VSWhere.cmake` and `NuGet.cmake` do work - including downloading files - when they're included, which is wasteful/noisy by default. This change moves the top-level logic into methods that do the necessary work, and adds a call to that method as needed, making the tooling download and initialization lazy.