### PR TITLE
Adding an initial '.cmake-format.yaml'

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -1,0 +1,45 @@
+format:
+  command_case: lower
+  dangle_parens: true
+  line_ending: windows
+  line_width: 120
+  max_pargs_hwrap: 3
+  separate_ctrl_name_with_space: false
+  separate_fn_name_with_space: false
+  tab_size: 4
+  use_tabchars: false
+
+parse:
+  additional_commands:
+    file:
+      pargs:
+        flags: [
+          'ARCHIVE_EXTRACT'
+        ]
+      kwargs:
+        INPUT: 1
+        DESTINATION: 1
+
+markup:
+  bullet_char: "*"
+  enable_markup: false
+  enum_char: .
+
+lint:
+  argument_var_pattern: '([A-Z][A-Z0-9_]+|[a-z_][a-z0-9_]+)'
+  local_var_pattern: '[A-Z][A-Z0-9_]+'
+  max_statements: 60
+  disabled_codes:
+    # Disable "Line too long", the current documentation tables have long lines.
+    - C0301
+
+    # Disable "Wrong line ending (unix)". See https://github.com/cheshirekow/cmake_format/issues/273
+    - C0327
+
+    # Disable "Empty docstring on function or macro declaration". CMakeLang doesn't appear to handle bracket comments
+    - C0112
+
+encode:
+  emit_byteorder_mark: false
+  input_encoding: utf-8
+  output_encoding: utf-8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,20 @@ on:
       - '*.md'
   workflow_dispatch:
 jobs:
+  analyze:
+    name: Run 'cmake-lint'
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install 'cmakelang[YAML]'
+        shell: pwsh
+        run: |
+          & pip install cmakelang[YAML]
+      - name: CMake lint
+        shell: pwsh
+        run: |
+          & ./analyze.ps1
   build:
     name: Build Examples
     strategy:

--- a/NuGet.cmake
+++ b/NuGet.cmake
@@ -133,7 +133,7 @@ function(install_nuget_package NUGET_PACKAGE_NAME NUGET_PACKAGE_VERSION VARIABLE
             OUTPUT_VARIABLE NUGET_OUTPUT
             ERROR_VARIABLE NUGET_ERROR
             RESULT_VARIABLE NUGET_RESULT
-            )
+        )
 
         message(VERBOSE "install_nuget_package: NUGET_OUTPUT = ${NUGET_OUTPUT}")
         if(NOT (NUGET_RESULT STREQUAL 0))

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ canonical to reduce the 'barrier-to-entry' to build code for Windows.
 
 [![build status](https://github.com/MarkSchofield/Toolchain/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/MarkSchofield/Toolchain/actions/workflows/ci.yaml?query=branch%3Amain)
 
-
 ## But I can build with MSVC in CMake already...?
 
 Yes, but you're probably either:
@@ -41,4 +40,18 @@ The ['Windows.MSVC.toolchain.cmake'](./Windows.MSVC.toolchain.cmake) and
 that can be used to configure the build. And [the example folder](./example) provides a CMake project that builds a
 variety of Windows projects.
 
+## Linting
+
+WindowsToolchain uses [`cmakelang`][cmakelang] for linting the CMake files in the codebase. The
+[.cmake-format.yaml](./.cmake-format.yaml) file describes the formatting style for the codebase. To run the linting
+tools:
+
+1. Install [`cmakelang`][cmakelang] following [the installation instuctions](https://cmake-format.readthedocs.io/en/latest/installation.html).
+Note: Since WindowsToolchain uses a `.yaml` file for configuration, make sure to install the `cmakelang[YAML]` package.
+
+2. Run [`./analyze.ps1`](./analyze.ps1)
+
+The [Toolchain CI](.\.github\workflows\ci.yaml) GitHub Workflow enforces the linting rules during PR and CI.
+
 [cmake-toolchains]: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html "CMake Toolchains"
+[cmakelang]: https://cmake-format.readthedocs.io/ "cmakelang"

--- a/Support/CppWinRT.cmake
+++ b/Support/CppWinRT.cmake
@@ -82,7 +82,7 @@ function(generate_winrt_projection)
         execute_process(
             COMMAND ${CPPWINRT_COMMAND}
             OUTPUT_VARIABLE CPPWINRT_OUTPUT
-            )
+        )
 
         message(VERBOSE "generate_winrt_projection: CPPWINRT_OUTPUT = ${CPPWINRT_OUTPUT}")
     endif()
@@ -160,10 +160,12 @@ function(add_cppwinrt_projection TARGET_NAME)
     set(CPPWINRT_EXECUTABLE_PATH ${NUGET_MICROSOFT_WINDOWS_CPPWINRT}/bin/cppwinrt.exe)
 
     set(CPPWINRT_COMMAND)
-    list(APPEND CPPWINRT_COMMAND ${CPPWINRT_EXECUTABLE_PATH})
-    list(APPEND CPPWINRT_COMMAND -output ${CPPWINRT_OUTPUT})
-    list(APPEND CPPWINRT_COMMAND -input ${CPPWINRT_INPUTS})
-    list(APPEND CPPWINRT_COMMAND -ref ${CPPWINRT_REFS})
+    list(APPEND CPPWINRT_COMMAND
+        ${CPPWINRT_EXECUTABLE_PATH}
+        -output ${CPPWINRT_OUTPUT}
+        -input ${CPPWINRT_INPUTS}
+        -ref ${CPPWINRT_REFS}
+    )
 
     if(CPPWINRT_OPTIMIZE)
         list(APPEND CPPWINRT_COMMAND -optimize)

--- a/Support/MidlRT.cmake
+++ b/Support/MidlRT.cmake
@@ -73,7 +73,7 @@ function(_generateMidlPlatformResponseFile)
     file(GENERATE
         OUTPUT ${MIDL_PLATFORM_RESPONSE_FILE}
         CONTENT "/nologo ${PLATFORM_REFERENCE_WINMDS_ARGS} ${PLATFORM_METADATA_PATHS_ARGS}"
-        )
+    )
 endfunction()
 
 #----------------------------------------------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ function(_generateMdMergePlatformResponseFile)
     file(GENERATE
         OUTPUT ${MDMERGE_PLATFORM_RESPONSE_FILE}
         CONTENT "-v ${PLATFORM_REFERENCE_PATHS_ARGS}"
-        )
+    )
 endfunction()
 
 _generateMidlPlatformResponseFile()
@@ -197,7 +197,7 @@ ${MDMERGE_COMMAND_LINE}
             DEPENDS ${WINMD_FILES} ${MDMERGE_COMMAND_SCRIPT}
             COMMENT "Generating ${TARGET_NAME}.winmd"
             WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
-        )
+    )
 
     set(${TARGET_WINMD_FILE_VARIABLE} ${OUTPUT_TARGET_WINMD_FILE} PARENT_SCOPE)
 endfunction()
@@ -235,7 +235,7 @@ ${CPPWINRT_COMMAND_LINE}
             DEPENDS ${MERGED_WINMD_FILE} ${CPPWINRT_COMMAND_SCRIPT}
             COMMENT "Projecting ${TARGET_NAME}.winmd"
             WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
-        )
+    )
 endfunction()
 
 #----------------------------------------------------------------------------------------------------------------------
@@ -257,12 +257,12 @@ function(_cppwinrtPlatformProjection)
     ")
 
     add_custom_command(
-            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/winrt/base.h"
-            COMMAND ${CPPWINRT_COMMAND_SCRIPT}
-            DEPENDS ${MERGED_WINMD_FILE} ${CPPWINRT_COMMAND_SCRIPT}
-            COMMENT "Projecting 'Platform' .winmd"
-            WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
-        )
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/Generated Files/winrt/base.h"
+        COMMAND ${CPPWINRT_COMMAND_SCRIPT}
+        DEPENDS ${MERGED_WINMD_FILE} ${CPPWINRT_COMMAND_SCRIPT}
+        COMMENT "Projecting 'Platform' .winmd"
+        WORKING_DIRECTORY ${TARGET_SOURCE_DIR}
+    )
 endfunction()
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/VSWhere.cmake
+++ b/VSWhere.cmake
@@ -44,10 +44,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/ToolchainCommon.cmake")
     allow 'vswhere' to be downloaded once for all platforms.
 ====================================================================================================================]]#
 function(toolchain_ensure_vswhere)
-    set(_ProgramFiles "ProgramFiles(x86)")
     find_program(VSWHERE_PATH
         NAMES vswhere vswhere.exe
-        HINTS "$ENV{${_ProgramFiles}}/Microsoft Visual Studio/Installer"
+        HINTS "$ENV{ProgramFiles\(x86\)}/Microsoft Visual Studio/Installer"
     )
 
     # If vswhere isn't found, download it.
@@ -124,10 +123,12 @@ function(findVisualStudio)
     execute_process(
         COMMAND ${VSWHERE_COMMAND}
         OUTPUT_VARIABLE VSWHERE_OUTPUT
-        )
+    )
 
     message(VERBOSE "findVisualStudio: VSWHERE_OUTPUT = ${VSWHERE_OUTPUT}")
 
+    # Matches `VSWHERE_PROPERTY` in the `VSWHERE_OUTPUT` text in the format written by vswhere.
+    # The matched value is assigned to the variable `VARIABLE_NAME` in the parent scope.
     function(getVSWhereProperty VSWHERE_OUTPUT VSWHERE_PROPERTY VARIABLE_NAME)
         string(REGEX MATCH "${VSWHERE_PROPERTY}: [^\r\n]*" VSWHERE_VALUE "${VSWHERE_OUTPUT}")
         string(REPLACE "${VSWHERE_PROPERTY}: " "" VSWHERE_VALUE "${VSWHERE_VALUE}")

--- a/analyze.ps1
+++ b/analyze.ps1
@@ -1,0 +1,44 @@
+<#====================================================================================================================#
+Runs cmake-lint on all `.cmake` files in the Git repository
+=====================================================================================================================#>
+$Root = $PSScriptRoot
+
+function IsGitHubAction {
+    $env:GITHUB_ACTIONS -eq 'true'
+}
+
+function ReportError([string] $File, [string] $LineNumber, [string] $Message) {
+    if (IsGitHubAction) {
+        Write-Output "::error file=$File,line=$LineNumber::$Message"
+    } else {
+        Write-Output $Message
+    }
+}
+
+$Git = Get-Command git -ErrorAction SilentlyContinue
+if (-not $Git) {
+    Write-Error "Unable to find 'git'."
+}
+
+$CMakeLint = Get-Command cmake-lint -ErrorAction SilentlyContinue
+if (-not $CMakeLint) {
+    Write-Error "Unable to find 'cmake-lint'."
+}
+
+$Failed = $false;
+$CMakeFiles = & $Git ls-files "$Root/*.cmake"
+
+foreach ($CMakeFile in $CMakeFiles) {
+    & $CMakeLint $CMakeFile |
+    ForEach-Object {
+        if ($_ -match '^([^:]*):(\d+):(.*)$') {
+            ReportError -File $Matches[1] -LineNumber $Matches[2] -Message $_
+            $Failed = $true
+        }
+        else {
+            Write-Output $_
+        }
+    }
+}
+
+exit ($Failed ? 1 : 0)


### PR DESCRIPTION
This PR adds a '.cmake-format.yaml' file as suggested by @ClausKlein in #47. The rules enforce the style that was generally in use in the `.cmake` files in the repo and helped highlight places where things were inconsistent. I've added a simple `analyze.ps1` that runs `cmake-lint` across all files in the Git repo, and a Job to the existing CI Workflow that uses `analyze.ps1` to enforce the rules at CI- and PR- time.