### PR TITLE
Add 'add_import_library' for generating an import library from a list of exports

### DIFF
--- a/Support/Imports.cmake
+++ b/Support/Imports.cmake
@@ -1,0 +1,120 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+include_guard()
+
+#[[====================================================================================================================
+    add_import_library
+    ------------------
+
+    Creates an import library for a named library and a list of the libraries exports.
+
+    add_import_library(<target name>
+        NAME
+            <library name>
+        EXPORTS
+            <exports list>
+    )
+
+    Notes:
+        * `add_import_library` only works with MSVC compilers.
+        * The `<library name>` should be the name of the library without the `.dll` extension.
+        * The `<exports list>` should be the list of exports from the library.
+
+====================================================================================================================]]#
+function(add_import_library TARGET_NAME)
+
+    if((NOT(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")) AND (NOT(CMAKE_C_COMPILER_ID STREQUAL "MSVC")))
+        message(FATAL_ERROR "add_import_library only works with an MSVC compiler.")
+    endif()
+
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS NAME)
+    set(MULTI_VALUE_KEYWORDS EXPORTS)
+
+    cmake_parse_arguments(PARSE_ARGV 0 IMPORT "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    # Generate the .def file.
+    set(DEF_FILE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_library.def)
+    list(TRANSFORM IMPORT_EXPORTS PREPEND "\t")
+    list(TRANSFORM IMPORT_EXPORTS APPEND "\n")
+    list(APPEND DEF_FILE_CONTENTS
+        "LIBRARY ${IMPORT_NAME}\n"
+        "EXPORTS\n"
+        "${IMPORT_EXPORTS}"
+    )
+
+    file(WRITE "${DEF_FILE_PATH}.input" ${DEF_FILE_CONTENTS})
+    configure_file("${DEF_FILE_PATH}.input" ${DEF_FILE_PATH} COPYONLY)
+
+    # Use the .def file to generate the .lib file.
+    set(LIB_FILE_NAME ${TARGET_NAME}_library.lib)
+    set(LIB_FILE_PATH ${CMAKE_CURRENT_BINARY_DIR}/${LIB_FILE_NAME})
+
+    # Map CMAKE_SYSTEM_PROCESSOR values to LIB_MACHINE to pass as /MACHINE to CMAKE_AR
+    if((CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL x64))
+        set(LIB_MACHINE x64)
+    elseif((CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
+        OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+        OR (CMAKE_SYSTEM_PROCESSOR STREQUAL x86))
+        set(LIB_MACHINE ${CMAKE_SYSTEM_PROCESSOR})
+    else()
+        message(FATAL_ERROR "Unable to identify the library machine type from CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+
+    set(LIB_PROPERTIES "")
+    list(APPEND LIB_PROPERTIES
+        ${CMAKE_AR}
+        "\"/DEF:${DEF_FILE_PATH}\""
+        "\"/OUT:${LIB_FILE_PATH}\""
+        "/MACHINE:${LIB_MACHINE}"
+        /nodefaultlib
+        /nologo
+    )
+
+    add_custom_command(
+        OUTPUT ${LIB_FILE_PATH}
+        COMMAND ${LIB_PROPERTIES}
+        DEPENDS ${DEF_FILE_PATH}
+        COMMENT "Generating ${TARGET_NAME}.lib"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    add_custom_target(${TARGET_NAME}_library
+        DEPENDS ${LIB_FILE_PATH}
+        COMMENT "Generating ${TARGET_NAME}_library"
+    )
+
+    add_library(${TARGET_NAME}
+        INTERFACE
+    )
+
+    add_dependencies(${TARGET_NAME}
+        ${TARGET_NAME}_library
+    )
+
+    target_link_libraries(${TARGET_NAME}
+        INTERFACE
+            ${LIB_FILE_PATH}
+    )
+endfunction()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -22,6 +22,10 @@ add_subdirectory(CommandLine)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)
 
+if((CMAKE_CXX_COMPILER_ID STREQUAL MSVC) AND (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86)))
+    add_subdirectory(CommandLineImportLibrary)
+endif()
+
 if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL Clang))
     add_subdirectory(CommandLineWinRT)
     add_subdirectory(RuntimeComponent)

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -14,7 +14,7 @@
         "NUGET_PACKAGE_ROOT_PATH": "${sourceDir}/__packages",
         "CPPWINRT_VERSION": "2.0.220418.1",
         "CPPWINRT_PROJECTION_ROOT_PATH": "${sourceDir}/__cppwinrt",
-        "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.19041.0",
+        "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.22621.0",
         "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
       }
     },

--- a/example/CommandLineImportLibrary/CMakeLists.txt
+++ b/example/CommandLineImportLibrary/CMakeLists.txt
@@ -1,0 +1,25 @@
+#----------------------------------------------------------------------------------------------------------------------
+#
+#----------------------------------------------------------------------------------------------------------------------
+project(CommandLineImportLibrary LANGUAGES CXX)
+
+include(${WINDOWS_TOOLCHAIN_DIR}/Support/Imports.cmake)
+
+# An example of generating an import library for a DLL: 'ntdll.dll' exports 'NtCreateFile', but doesn't include
+# 'NtCreateFile' as an export in the 'ntdll.lib' import library shipped in the Windows SDK. Rather than calling
+# LoadLibrary/GetProcAddress to call 'NtCreateFile', generate an import library, and link to that.
+add_import_library(ntdll_imports
+    NAME
+        ntdll
+    EXPORTS
+        NtCreateFile
+)
+
+add_executable(CommandLineImportLibrary
+    main.cpp
+)
+
+target_link_libraries(CommandLineImportLibrary
+    PRIVATE
+        ntdll_imports
+)

--- a/example/CommandLineImportLibrary/main.cpp
+++ b/example/CommandLineImportLibrary/main.cpp
@@ -1,0 +1,40 @@
+//---------------------------------------------------------------------------------------------------------------------
+//
+//---------------------------------------------------------------------------------------------------------------------
+#include <exception>
+#include <iostream>
+
+#if defined(_M_X64) || defined(_M_AMD64)
+#    define _AMD64_
+#elif defined(_M_ARM)
+#    define _ARM_
+#elif defined(_M_ARM64)
+#    define _ARM64_
+#elif defined(_M_ARM64EC)
+#    define _ARM64EC_
+#elif defined(_M_IX86)
+#    define _X86_
+#else
+#    error Unknown platform
+#endif
+
+#include <sdkddkver.h>
+#include <winternl.h>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    try
+    {
+        try
+        {
+            std::cout << "Found NtCreateFile: " << &NtCreateFile;
+        }
+        catch (const std::exception& ex)
+        {
+            std::cout << "Exception: " << ex.what();
+        }
+    }
+    catch (...)
+    {
+    }
+}


### PR DESCRIPTION
This is not-necessarily 'toolchain' related, but MSVC-related. There are cases where there's a need to build an import library from a list of exports - where an import library isn't shipped with a DLL, or where the imports aren't included in the import library for the DLL. The 'Imports.cmake' file adds `add_import_library` to generate a target representing an import library with the given exports.