### PR TITLE
Tests should preserve and restore Location

### DIFF
--- a/Tests/Ninja/Toolchain.Ninja.Tests.ps1
+++ b/Tests/Ninja/Toolchain.Ninja.Tests.ps1
@@ -12,6 +12,12 @@ BeforeAll {
     $OutputPath = Join-Path -Path $PSScriptRoot -ChildPath __output
 
     $ToolsNinjaPath = Join-Path -Path $ToolsPath -ChildPath ninja.exe
+
+    $OriginalLocation = Get-Location
+}
+
+AfterAll {
+    Set-Location $OriginalLocation
 }
 
 Describe 'Windows.MSVC.toolchain.cmake Ninja support' {

--- a/Tests/NuGet/Toolchain.NuGet.Tests.ps1
+++ b/Tests/NuGet/Toolchain.NuGet.Tests.ps1
@@ -12,6 +12,12 @@ BeforeAll {
     $OutputPath = Join-Path -Path $PSScriptRoot -ChildPath __output
 
     $ToolsNuGetPath = Join-Path -Path $ToolsPath -ChildPath nuget.exe
+
+    $OriginalLocation = Get-Location
+}
+
+AfterAll {
+    Set-Location $OriginalLocation
 }
 
 Describe 'Windows.MSVC.toolchain.cmake NuGet support' {


### PR DESCRIPTION
After running the Pester tests, the shell's location changes - the tests themselves change location, so the shell's location is left in the location of the last test that changed location. The tests should use BeforeAll/AfterAll to preserve and restore location.