### PR TITLE
Leverage CppWinRT's module

### DIFF
--- a/Support/CppWinRT.cmake
+++ b/Support/CppWinRT.cmake
@@ -204,9 +204,26 @@ function(add_cppwinrt_projection TARGET_NAME)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
 
-    add_library(${TARGET_NAME} INTERFACE
-        ${CPPWINRT_OUTPUT_FILE}
-    )
+    if((EXISTS ${CPPWINRT_OUTPUT}/winrt/winrt.ixx) AND CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API)
+        add_library(${TARGET_NAME}
+            ${CPPWINRT_OUTPUT_FILE}
+        )
+
+        target_compile_features(${TARGET_NAME}
+            PRIVATE
+                cxx_std_20
+        )
+
+        target_sources(${TARGET_NAME}
+            PUBLIC FILE_SET CXX_MODULES TYPE CXX_MODULES
+            FILES
+                ${CPPWINRT_OUTPUT}/winrt/winrt.ixx
+        )
+    else()
+        add_library(${TARGET_NAME} INTERFACE
+            ${CPPWINRT_OUTPUT_FILE}
+        )
+    endif()
 
     target_include_directories(${TARGET_NAME} BEFORE
         INTERFACE

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -12,10 +12,14 @@
       "cacheVariables": {
         "TOOLCHAIN_TOOLS_PATH": "${sourceDir}/__tools",
         "NUGET_PACKAGE_ROOT_PATH": "${sourceDir}/__packages",
-        "CPPWINRT_VERSION": "2.0.220418.1",
+        "CPPWINRT_VERSION": "2.0.230207.1",
         "CPPWINRT_PROJECTION_ROOT_PATH": "${sourceDir}/__cppwinrt",
         "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM": "10.0.22621.0",
-        "CMAKE_SYSTEM_VERSION": "10.0.19041.0"
+        "CMAKE_SYSTEM_VERSION": "10.0.19041.0",
+        "CMAKE_EXPERIMENTAL_CXX_MODULE_DYNDEP": "1",
+        // 3.25.2  = 3c375311-a3c9-4396-a187-3227ef642046
+        // Nightly = 2182bf5c-ef0d-489a-91da-49dbc3090d2a
+        "CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API": "2182bf5c-ef0d-489a-91da-49dbc3090d2a"
       }
     },
     {

--- a/example/CommandLineWinRT/CMakeLists.txt
+++ b/example/CommandLineWinRT/CMakeLists.txt
@@ -12,10 +12,13 @@ target_compile_features(CommandLineWinRT
         cxx_std_17
 )
 
-target_precompile_headers(CommandLineWinRT
-    PRIVATE
-        pch.h
-)
+# Precompiled headers cause a dependency cycle with module support
+if(NOT CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API)
+    target_precompile_headers(CommandLineWinRT
+        PRIVATE
+            pch.h
+    )
+endif()
 
 target_link_libraries(CommandLineWinRT
     PRIVATE

--- a/example/RuntimeComponent/CMakeLists.txt
+++ b/example/RuntimeComponent/CMakeLists.txt
@@ -17,10 +17,13 @@ target_compile_features(RuntimeComponent
         cxx_std_17
 )
 
-target_precompile_headers(RuntimeComponent
-    PRIVATE
-        pch.h
-)
+# Precompiled headers cause a dependency cycle with module support
+if(NOT CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API)
+    target_precompile_headers(RuntimeComponent
+        PRIVATE
+            pch.h
+    )
+endif()
 
 target_link_libraries(RuntimeComponent
     PRIVATE

--- a/example/SharedLibrary/CMakeLists.txt
+++ b/example/SharedLibrary/CMakeLists.txt
@@ -13,7 +13,10 @@ target_compile_definitions(SharedLibrary
         PROJECT1_EXPORTS
 )
 
-target_precompile_headers(SharedLibrary
-    PRIVATE
-        pch.h
-)
+# Precompiled headers cause a dependency cycle with module support
+if(NOT CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API)
+    target_precompile_headers(SharedLibrary
+        PRIVATE
+            pch.h
+    )
+endif()


### PR DESCRIPTION
Note: This doesn't actually work yet. For me, at least. I'll continue to work through issues...

CMake 3.25 has experimental support for C++20 modules. CppWinRT generates a module for OS projections. This PR attempts to enable the CMake support to leverage the CppWinRT module. This PR:
1. Enables CMake's experimental module support by setting `CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API` as necessary. `CMAKE_EXPERIMENTAL_CXX_MODULE_CMAKE_API` needs to be set to a specific UUID corresponding to the specific behavior that is being used. The current UUID in this PR corresponds to the current (as of 1/28/2023) nightly build.
2. Looks for the generated `winrt.ixx` file by `cppwinrt.exe` and if present - and module support has been enabled - attempts to enable module support by adding the `FILE_SET CXX_MODULES` details, as outlined in [this blog post]()

There's a couple of problems:
1. With module support enabled, Ninja complains that CMake has generated a cycle with the precompiled headers. So I've disabled precompiled headers when modules are being used.
2. My MSVC wedges when compiling `winrt.ixx`.

Resources:
    https://github.com/Kitware/CMake/blob/master/Help/dev/experimental.rst