### PR TITLE
Use a more generic regex to get msvc version

### DIFF
--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -149,7 +149,7 @@ function(getMsvcVersion COMPILER MSVC_VERSION_OUTPUT)
         OUTPUT_QUIET
     )
 
-    if(COMPILER_OUTPUT MATCHES "Compiler Version (([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.([0-9]+))?)")
+    if(COMPILER_OUTPUT MATCHES "cl.exe.*(([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.([0-9]+))?)")
         set(COMPILER_VERSION ${CMAKE_MATCH_1})
         set(COMPILER_VERSION_MAJOR ${CMAKE_MATCH_2})
         set(COMPILER_VERSION_MINOR ${CMAKE_MATCH_3})


### PR DESCRIPTION
The origin regex which aimed to getting msvc version only worked when msvc displays English. That is, the regex matches the version after `Compiler Version`, It dosen't work when msvc displays other languages. For instance, in Chinese, msvc outputs `版本 <version>` instead of `Compiler Version <version>`.

I replace the regex based on the observation that the scanning always returns the path of cl.exe trailing with the msvc version.