### PR TITLE
VS_USE_SPECTRE_MITIGATION_RUNTIME should prefer the Spectre library path, not use it exclusively

### DIFF
--- a/VSWhere.cmake
+++ b/VSWhere.cmake
@@ -24,6 +24,40 @@
 include_guard()
 
 #[[====================================================================================================================
+    toolchain_validate_vs_files
+    ---------------------------
+
+    Note: Not supported for consumption outside of the toolchain files.
+
+    Validates the the specified folder exists and contains the specified files.
+
+        toolchain_validate_vs_files(
+            <DESCRIPTION <description>>
+            <FOLDER <folder>>
+            <FILES <file>...>
+        )
+
+    If the folder or files are missing, then a FATAL_ERROR is reported.
+====================================================================================================================]]#
+function(toolchain_validate_vs_files)
+    set(OPTIONS)
+    set(ONE_VALUE_KEYWORDS FOLDER DESCRIPTION)
+    set(MULTI_VALUE_KEYWORDS FILES)
+
+    cmake_parse_arguments(PARSE_ARGV 0 VS "${OPTIONS}" "${ONE_VALUE_KEYWORDS}" "${MULTI_VALUE_KEYWORDS}")
+
+    if(NOT EXISTS ${VS_FOLDER})
+        message(FATAL_ERROR "Folder not present - ${VS_FOLDER} - ensure that the ${VS_DESCRIPTION} are installed with Visual Studio.")
+    endif()
+
+    foreach(FILE ${VS_FILES})
+        if(NOT EXISTS "${VS_FOLDER}/${FILE}")
+            message(FATAL_ERROR "File not present - ${VS_FOLDER}/${FILE} - ensure that the ${VS_DESCRIPTION} are installed with Visual Studio.")
+        endif()
+    endforeach()
+endfunction()
+
+#[[====================================================================================================================
     findVisualStudio
     ----------------
 


### PR DESCRIPTION
`VS_USE_SPECTRE_MITIGATION_RUNTIME` instructs the toolchain to switch the library include path for the compiler runtime to a `spectre` sub-directory. When compiling with MSVC's ASAN support (i.e. `/fsanitize=address`) the compilation depends on `.lib` files that _aren't_ present in the `spectre` sub-directory, but _are_ present in the default library include path, breaking ASAN builds if `VS_USE_SPECTRE_MITIGATION_RUNTIME` is used. If `VS_USE_SPECTRE_MITIGATION_RUNTIME` were to _prefer_ the `spectre` subdirectory - rather than using it exclusively - then the ASAN libraries would still be found.