### PR TITLE
Fix regex to get MSVC version

### DIFF
--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -145,7 +145,7 @@ function(getMsvcVersion COMPILER MSVC_VERSION_OUTPUT)
         OUTPUT_QUIET
     )
 
-    if(COMPILER_OUTPUT MATCHES "cl.exe.*(([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.([0-9]+))?)")
+    if(COMPILER_OUTPUT MATCHES "cl\\.exe[^0-9]*(([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.([0-9]+))?)")
         set(COMPILER_VERSION ${CMAKE_MATCH_1})
         set(COMPILER_VERSION_MAJOR ${CMAKE_MATCH_2})
         set(COMPILER_VERSION_MINOR ${CMAKE_MATCH_3})


### PR DESCRIPTION
The MSVC version number is not being properly parsed through the `cl.exe -Bv` command on my machine. The issue seems to be with the greedy regex pattern `.*` which matches the rest of the line eating up the version number. Changing this pattern to `[^0-9]*` seems to work fine.