### PR TITLE
Add a Windows.EWDK.toolchain.cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
-# A CMake Toolchain file for Windows MSVC and Windows Clang
+# CMake Toolchain files for Windows
 
 A CMake toolchain file describes the set of tools and utilities for compiling code in CMake. This repo provides
 toolchains that describes how to compile using MSVC and Clang in CMake, with the goal of making Windows CMake builds more
 canonical to reduce the 'barrier-to-entry' to build code for Windows.
+
+This repo contains three toolchains:
+
+1. [Windows.MSVC.toolchain.cmake](./Windows.MSVC.toolchain.cmake) - Uses the MSVC compiler from an installed Visual Studio
+instance.
+
+2. [Windows.Clang.toolchain.cmake](./Windows.Clang.toolchain.cmake) - Uses Clang from either an LLVM installation or from
+a Visual Studio installation.
+
+3. [Windows.EWDK.toolchain.cmake](./Windows.EWDK.toolchain.cmake) - Uses the MSVC compiler from an [Enterprise Windows Driver Kit][ewdk].
+This toolchain requires that CMake be invoked from an EWDK build prompt.
+
+Each toolchain will find a compiler, runtime and a Windows SDK.
 
 [![build status](https://github.com/MarkSchofield/Toolchain/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/MarkSchofield/Toolchain/actions/workflows/ci.yaml?query=branch%3Amain)
 
@@ -33,14 +46,13 @@ conversation.
 
 ## How do I use this?
 
-Specify the 'Windows.MSVC.toolchain.cmake' or 'Windows.Clang.toolchain.cmake' file as a toolchain file to your CMake
-builds. See [the documentation for CMake toolchains][cmake-toolchains] for more details on Toolchain files and how to
-consume them.
+Simply specify one of the toolchain files to your CMake builds. See [the documentation for CMake toolchains][cmake-toolchains]
+for more details on Toolchain files and how to consume them.
 
-The ['Windows.MSVC.toolchain.cmake'](./Windows.MSVC.toolchain.cmake) and
-['Windows.Clang.toolchain.cmake'](./Windows.Clang.toolchain.cmake) file has details on the various CMake variables
+Each toolchain file (['Windows.MSVC.toolchain.cmake'](./Windows.MSVC.toolchain.cmake), ['Windows.Clang.toolchain.cmake'](./Windows.Clang.toolchain.cmake),
+or [Windows.EWDK.toolchain.cmake](./Windows.EWDK.toolchain.cmake)) has details on the various CMake properties
 that can be used to configure the build. And [the example folder](./example) provides a CMake project that builds a
-variety of Windows projects.
+variety of Windows projects, using each of the toolchain files.
 
 ## WindowsToolchain and VCPkg
 
@@ -115,3 +127,4 @@ The [Toolchain CI](.\.github\workflows\ci.yaml) GitHub Workflow requires all tes
 [cmakelang]: https://cmake-format.readthedocs.io/ "cmakelang"
 [pester]: https://pester.dev/ "Pester"
 [powershellcore]: https://learn.microsoft.com/en-us/powershell/ "PowerShell Core"
+[ewdk]: https://learn.microsoft.com/en-us/windows-hardware/drivers/develop/using-the-enterprise-wdk "Enterprise Windows Driver Kit"

--- a/Windows.EWDK.toolchain.cmake
+++ b/Windows.EWDK.toolchain.cmake
@@ -1,0 +1,113 @@
+#----------------------------------------------------------------------------------------------------------------------
+# MIT License
+#
+# Copyright (c) 2021 Mark Schofield
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#----------------------------------------------------------------------------------------------------------------------
+#
+# This CMake toolchain file configures a CMake, non-'Visual Studio Generator' build to use
+# the Enterprise Windows Driver Kit.
+#
+# The toolchain expects the following environment variables to have been initialized by the EWDK build environment:
+#
+# | CMake Variable                              | Description                                                                                           |
+# |---------------------------------------------|-------------------------------------------------------------------------------------------------------|
+# | VCToolsVersion                              | The version of the MSVC platform toolset to use (e.g. 14.31.31103).                                   |
+# | VSCMD_ARG_HOST_ARCH                         | The architecture of the host tooling to use (e.g. x86).                                               |
+# | VSCMD_ARG_TGT_ARCH                          | The architecture to build for (e.g. arm64).                                                           |
+# | VSINSTALLDIR                                | The path to the Visual Studio instance to use.                                                        |
+# | WindowsSdkDir                               | The path to the Windows SDK directory                                                                 |
+# | Version_Number                              | The version of the Windows SDK to use.                                                                |
+#
+# The following variables can be used to configure the behavior of this toolchain file:
+#
+# | CMake Variable                              | Description                                                                                           |
+# |---------------------------------------------|-------------------------------------------------------------------------------------------------------|
+# | CMAKE_SYSTEM_VERSION                        | The version of the operating system for which CMake is to build. Defaults to the host version.        |
+# | VS_EXPERIMENTAL_MODULE                      | Whether experimental module support should be enabled.                                                |
+# | VS_USE_SPECTRE_MITIGATION_RUNTIME           | Whether the compiler should link with a runtime that uses 'Spectre' mitigations. Defaults to 'OFF'.   |
+#
+# The toolchain file will set the following variables:
+#
+# | CMake Variable                              | Description                                                                                           |
+# |---------------------------------------------|-------------------------------------------------------------------------------------------------------|
+# | CMAKE_C_COMPILER                            | The path to the C compiler to use.                                                                    |
+# | CMAKE_CXX_COMPILER                          | The path to the C++ compiler to use.                                                                  |
+# | CMAKE_MT                                    | The path to the 'mt.exe' tool to use.                                                                 |
+# | CMAKE_RC_COMPILER                           | The path tp the 'rc.exe' tool to use.                                                                 |
+# | CMAKE_SYSTEM_NAME                           | 'Windows'                                                                                             |
+# | CMAKE_SYSTEM_PROCESSOR                      | The architecture to build for (e.g. arm64).                                                           |
+# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE | The architecture of the host tooling to use (e.g. x86).                                               |
+# | CMAKE_VS_PLATFORM_TOOLSET_VERSION           | The version of the MSVC platform toolset to use (e.g. 14.31.31103).                                   |
+# | CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION    | The version of the Windows SDK to use.                                                                |
+# | CMAKE_WINDOWS_KITS_10_DIR                   | The path to the Windows SDK directory                                                                 |
+# | MSVC                                        | 1                                                                                                     |
+# | MSVC_VERSION                                | The '<major><minor>' version of the C++ compiler being used. For example, '1929'                      |
+# | VS_INSTALLATION_PATH                        | The path to the Visual Studio instance to use.                                                        |
+# | WIN32                                       | 1                                                                                                     |
+#
+# Resources:
+#   <https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html>
+#
+cmake_minimum_required(VERSION 3.20)
+
+include_guard()
+
+if("$ENV{BuildLabSetupRoot}" STREQUAL "")
+    message(FATAL_ERROR "The ${CMAKE_CURRENT_LIST_FILE} toolchain can only be used from an initialized EWDK build prompt.")
+endif()
+
+if(CMAKE_SYSTEM_PROCESSOR)
+    if(NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL $ENV{VSCMD_ARG_TGT_ARCH}))
+        message(FATAL_ERROR "The 'CMAKE_SYSTEM_PROCESSOR' property - if set - must match the VSCMD_ARG_TGT_ARCH environment variable.")
+    endif()
+else()
+    set(CMAKE_SYSTEM_PROCESSOR $ENV{VSCMD_ARG_TGT_ARCH})
+    if(NOT CMAKE_SYSTEM_PROCESSOR)
+        message(FATAL_ERROR "The 'VSCMD_ARG_TGT_ARCH' environment variable should specify the architecture of the host toolset to use.")
+    endif()
+endif()
+
+set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE $ENV{VSCMD_ARG_HOST_ARCH})
+if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE)
+    message(FATAL_ERROR "The 'VSCMD_ARG_HOST_ARCH' environment variable should specify the architecture of the host toolset to use.")
+endif()
+
+set(VS_INSTALLATION_PATH $ENV{VSINSTALLDIR})
+if(NOT VS_INSTALLATION_PATH)
+    message(FATAL_ERROR "The 'VSINSTALLDIR' environment variable should specify the location of Visual Studio.")
+endif()
+
+set(VS_PLATFORM_TOOLSET_VERSION $ENV{VCToolsVersion})
+if(NOT VS_PLATFORM_TOOLSET_VERSION)
+    message(FATAL_ERROR "The 'VCToolsVersion' environment variable should specify the VC toolset version to use.")
+endif()
+
+set(CMAKE_WINDOWS_KITS_10_DIR $ENV{WindowsSdkDir})
+if(NOT CMAKE_WINDOWS_KITS_10_DIR)
+    message(FATAL_ERROR "The 'WindowsSdkDir' environment variable should specify the root of the Windows SDK.")
+endif()
+
+set(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION $ENV{Version_Number})
+if(NOT CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION)
+    message(FATAL "The 'Version_Number' environment variable should specify the version of the Windows SDK to use.")
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/Windows.MSVC.toolchain.cmake")

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,7 +15,7 @@ add_subdirectory(CommandLineC)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND VS_EXPERIMENTAL_MODULE)
     if((CMAKE_SYSTEM_PROCESSOR STREQUAL x64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL x86))
         add_subdirectory(CommandLineModule)
     endif()

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -44,6 +44,18 @@
       "binaryDir": "${sourceDir}/__output/${presetName}"
     },
     {
+      "name": "ewdk",
+      "displayName": "EWDK configuration",
+      "description": "This build is only available on Windows",
+      "generator": "Ninja Multi-Config",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "../Windows.EWDK.toolchain.cmake",
+        "VS_EXPERIMENTAL_MODULE": "OFF",
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "ON"
+      },
+      "binaryDir": "${sourceDir}/__output/${presetName}-$env{VSCMD_ARG_TGT_ARCH}"
+    },
+    {
       "name": "windows-msvc-x64",
       "inherits": "windows-msvc",
       "displayName": "Configure for 'windows-msvc-x64'",
@@ -124,6 +136,10 @@
     {
       "name": "windows-clang-amd64",
       "configurePreset": "windows-clang-amd64"
+    },
+    {
+      "name": "ewdk",
+      "configurePreset": "ewdk"
     }
   ]
 }


### PR DESCRIPTION
As @kaloth called out in #74, using WindowsToolchain from an Enterprise WDK environment is a bit tricky. That review - I think - got the minimal fixes in to make it possible, this is a rough PR to get a better solution in place. There's work still to do:

 - [x] This includes fixes for the Windows.MSVC.toolchain.cmake file that I'll break-off, send separately, and then resolve this branch against.
 - [x] Documentation needs to be written.
 - [ ] ~Ideally, some tests would be added. Unfortunately, the GitHub Actions images don't include the EWDK, so if I want to add tests, then I'll need to download the 16GB ISO, figure out how to mount it, and then run some builds. That sounds a bit tricky and slow.~ Not in scope - see my comment; GitHub runners only have 14 GB of space, which is too small to download the 16 GB EWDK iso.

Feedback on the code and above points is welcomed!

----

This PR adds the "Windows.EWDK.toolchain.cmake" file to make CMake builds with the EWDK easier - converting EWDK-initialized environment variables to CMake properties to then use "Windows.MSVC.toolchain.cmake" 