### PR TITLE
Avoid setting MSVC_VERSION in the toolchain, rely on CMake setting it (and others)

### DIFF
--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -152,21 +152,6 @@ set(VS_TOOLSET_PATH "${VS_INSTALLATION_PATH}/VC/Tools/MSVC/${CMAKE_VS_PLATFORM_T
 
 # Set the tooling variables, include_directories and link_directories
 #
-function(getMsvcVersion COMPILER MSVC_VERSION_OUTPUT)
-    execute_process(
-        COMMAND "${COMPILER}" -Bv
-        ERROR_VARIABLE COMPILER_OUTPUT
-        OUTPUT_QUIET
-    )
-
-    if(COMPILER_OUTPUT MATCHES "cl\\.exe[^0-9]*(([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\.([0-9]+))?)")
-        set(COMPILER_VERSION ${CMAKE_MATCH_1})
-        set(COMPILER_VERSION_MAJOR ${CMAKE_MATCH_2})
-        set(COMPILER_VERSION_MINOR ${CMAKE_MATCH_3})
-    endif()
-
-    set(${MSVC_VERSION_OUTPUT} "${COMPILER_VERSION_MAJOR}${COMPILER_VERSION_MINOR}" PARENT_SCOPE)
-endfunction()
 
 # Map CMAKE_SYSTEM_PROCESSOR values to CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE that identifies the tools that should
 # be used to produce code for the CMAKE_SYSTEM_PROCESSOR.
@@ -185,11 +170,6 @@ set(CMAKE_C_COMPILER "${VS_TOOLSET_PATH}/bin/Host${CMAKE_VS_PLATFORM_TOOLSET_HOS
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
     set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} /EHsc")
-endif()
-
-getMsvcVersion(${CMAKE_CXX_COMPILER} MSVC_VERSION)
-if(NOT MSVC_VERSION)
-    message(FATAL_ERROR "Unable to obtain the compiler version from: ${CMAKE_CXX_COMPILER}")
 endif()
 
 # Compiler

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,6 +5,11 @@ cmake_minimum_required(VERSION 3.20)
 
 project(WindowsToolchainExample)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+    message(STATUS "MSVC_VERSION = ${MSVC_VERSION}")
+    message(STATUS "MSVC_TOOLSET_VERSION = ${MSVC_TOOLSET_VERSION}")
+endif()
+
 add_compile_definitions(
     UNICODE
     _UNICODE


### PR DESCRIPTION
#90 identified that the [`MSVC_TOOLSET_VERSION`](https://cmake.org/cmake/help/latest/variable/MSVC_TOOLSET_VERSION.html) isn't set when using the `Windows.EWDK.toolchain.cmake`. It turns out that it's not set when using the `Windows.MSVC.toolchain.cmake` either.

The toolchain files _do_ set [`MSVC_VERSION`](https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html), and that's the problem. By setting `MSVC_VERSION`, we end-up bypassing CMake's code to automatically set `MSVC_TOOLSET_VERSION` (and other variables) for us in [CMake/Modules/Platform/Windows-MSVC.cmake](https://github.com/Kitware/CMake/blob/bef9f0920f4f89d29e0c1138d377f19a0130f79a/Modules/Platform/Windows-MSVC.cmake#L48C1-L48C21). Removing the toolchain's code to calculate `MSVC_VERSION` seems like the right thing to do:

1. It's less code in the Toolchain files.
2. It's one fewer processes created during configuration.
3. The CMake logic sets all of the right variables.
