### PR TITLE
Add 'app.manifest' to example/WindowsApplication, mark as DPI aware

### DIFF
--- a/example/WindowsApplication/CMakeLists.txt
+++ b/example/WindowsApplication/CMakeLists.txt
@@ -4,6 +4,7 @@
 project(WindowsApplication LANGUAGES CXX)
 
 add_executable(WindowsApplication WIN32
+    app.manifest
     WindowsApplication.cpp
     WindowsApplication.rc
 )

--- a/example/WindowsApplication/app.manifest
+++ b/example/WindowsApplication/app.manifest
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" manifestVersion="1.0">
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns="https://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor,unaware</dpiAwareness>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <maxversiontested Id="10.0.18362.0"/>
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+        </application>
+    </compatibility>
+</assembly>


### PR DESCRIPTION
Add a manifest to 'example/WindowsApplication' to...

* ...show how to add desktop manifests to a CMake build
* ...mark the application as DPI-aware, so that the menus look better on a high-DPI monitor.