### PR TITLE
Change example defaults to build by default

### DIFF
--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -25,7 +25,7 @@
         "CMAKE_TOOLCHAIN_FILE": "../Windows.MSVC.toolchain.cmake",
         "CMAKE_VS_VERSION_PRERELEASE": "ON",
         "VS_EXPERIMENTAL_MODULE": "ON",
-        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "ON"
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF"
       },
       "binaryDir": "${sourceDir}/__output/${presetName}"
     },
@@ -141,7 +141,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "../Windows.EWDK.toolchain.cmake",
         "VS_EXPERIMENTAL_MODULE": "OFF",
-        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "ON"
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF"
       },
       "binaryDir": "${sourceDir}/__output/${presetName}-$env{VSCMD_ARG_TGT_ARCH}"
     }

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -24,7 +24,7 @@
       "cacheVariables": {
         "CMAKE_TOOLCHAIN_FILE": "../Windows.MSVC.toolchain.cmake",
         "CMAKE_VS_VERSION_PRERELEASE": "ON",
-        "VS_EXPERIMENTAL_MODULE": "ON",
+        "VS_EXPERIMENTAL_MODULE": "OFF",
         "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF"
       },
       "binaryDir": "${sourceDir}/__output/${presetName}"


### PR DESCRIPTION
The 'CMakePresets.json' file in the 'example' folder opts-in to functionality that requires opt-in features from Visual Studio:

1. `VS_USE_SPECTRE_MITIGATION_RUNTIME` - This uses the Spectre-mitigation runtimes by default, but Visual Studio doesn't install them by default.
2. `VS_EXPERIMENTAL_MODULE` - This adds the Visual Studio-shipped modules for C++ to the path, but Visual Studio doesn't install them by default.

Setting these options to `OFF` means that a default install of Visual Studio - with the C++ workload - should be able to build the examples.