### PR TITLE
Windows.MSVC.toolchain.cmake shouldn't fallback to non-Spectre folders on Spectre builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         configuration: [ Debug, Release ]
-        buildPreset: [ windows-msvc-x64, windows-msvc-amd64, windows-msvc-x86, windows-msvc-arm64, windows-clang-x64, windows-clang-amd64, windows-clangcl-x64, windows-clangcl-amd64 ]
+        buildPreset: [ windows-msvc-x64, windows-msvc-spectre-x64, windows-msvc-amd64, windows-msvc-x86, windows-msvc-arm64, windows-clang-x64, windows-clang-amd64, windows-clangcl-x64, windows-clangcl-amd64 ]
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -188,6 +188,8 @@ if(VS_USE_SPECTRE_MITIGATION_ATLMFC_RUNTIME)
             atls.lib
     )
     link_directories("${VS_TOOLSET_PATH}/ATLMFC/lib/spectre/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
+else()
+    link_directories("${VS_TOOLSET_PATH}/ATLMFC/lib/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
 endif()
 
 if(VS_USE_SPECTRE_MITIGATION_RUNTIME)
@@ -199,10 +201,9 @@ if(VS_USE_SPECTRE_MITIGATION_RUNTIME)
             msvcrt.lib vcruntime.lib vcruntimed.lib
     )
     link_directories("${VS_TOOLSET_PATH}/lib/spectre/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
+else()
+    link_directories("${VS_TOOLSET_PATH}/lib/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
 endif()
-
-link_directories("${VS_TOOLSET_PATH}/ATLMFC/lib/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
-link_directories("${VS_TOOLSET_PATH}/lib/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
 
 link_directories("${VS_TOOLSET_PATH}/lib/x86/store/references")
 

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -30,6 +30,17 @@
       }
     },
     {
+      "name": "windows-msvc-spectre",
+      "inherits": "windows-msvc",
+      "hidden": true,
+      "displayName": "Windows-only configuration",
+      "description": "This build is only available on Windows",
+      "cacheVariables": {
+        "VS_USE_SPECTRE_MITIGATION_ATLMFC_RUNTIME": "ON",
+        "VS_USE_SPECTRE_MITIGATION_RUNTIME": "ON"
+      }
+    },
+    {
       "name": "windows-clang",
       "inherits": "windows",
       "hidden": true,
@@ -57,6 +68,15 @@
       "name": "windows-msvc-x64",
       "inherits": "windows-msvc",
       "displayName": "Configure for 'windows-msvc-x64'",
+      "binaryDir": "${sourceDir}/__output/${presetName}",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_PROCESSOR": "x64"
+      }
+    },
+    {
+      "name": "windows-msvc-spectre-x64",
+      "inherits": "windows-msvc-spectre",
+      "displayName": "Configure for 'windows-msvc-spectre-x64'",
       "binaryDir": "${sourceDir}/__output/${presetName}",
       "cacheVariables": {
         "CMAKE_SYSTEM_PROCESSOR": "x64"
@@ -144,6 +164,10 @@
     {
       "name": "windows-msvc-x64",
       "configurePreset": "windows-msvc-x64"
+    },
+    {
+      "name": "windows-msvc-spectre-x64",
+      "configurePreset": "windows-msvc-spectre-x64"
     },
     {
       "name": "windows-msvc-amd64",

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -25,9 +25,9 @@
         "CMAKE_TOOLCHAIN_FILE": "../Windows.MSVC.toolchain.cmake",
         "CMAKE_VS_VERSION_PRERELEASE": "ON",
         "VS_EXPERIMENTAL_MODULE": "OFF",
+        "VS_USE_SPECTRE_MITIGATION_ATLMFC_RUNTIME": "OFF",
         "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF"
-      },
-      "binaryDir": "${sourceDir}/__output/${presetName}"
+      }
     },
     {
       "name": "windows-clang",
@@ -40,24 +40,18 @@
         "CMAKE_TOOLCHAIN_FILE": "../Windows.Clang.toolchain.cmake",
         "CMAKE_VS_VERSION_RANGE": "[16.0,18.0)",
         "CMAKE_VS_VERSION_PRERELEASE": "ON"
-      },
-      "binaryDir": "${sourceDir}/__output/${presetName}"
+      }
     },
     {
       "name": "windows-clangcl",
-      "inherits": "windows",
+      "inherits": "windows-clang",
       "hidden": true,
       "displayName": "Windows-only configuration",
       "description": "This build is only available on Windows",
-      "generator": "Ninja Multi-Config",
       "cacheVariables": {
         "CMAKE_C_COMPILER_FRONTEND_VARIANT": "MSVC",
-        "CMAKE_CXX_COMPILER_FRONTEND_VARIANT": "MSVC",
-        "CMAKE_TOOLCHAIN_FILE": "../Windows.Clang.toolchain.cmake",
-        "CMAKE_VS_VERSION_RANGE": "[16.0,18.0)",
-        "CMAKE_VS_VERSION_PRERELEASE": "ON"
-      },
-      "binaryDir": "${sourceDir}/__output/${presetName}"
+        "CMAKE_CXX_COMPILER_FRONTEND_VARIANT": "MSVC"
+      }
     },
     {
       "name": "windows-msvc-x64",


### PR DESCRIPTION
[Discussion #93](https://github.com/MarkSchofield/WindowsToolchain/discussions/93) talks about the options of opt-ing-in-to and falling-back-from Spectre libraries. This PR changes behavior to *not* include the non-Spectre paths if Spectre libraries have been asked for. 