### PR TITLE
Prefer the 'arm64' host compiler on ARM64 hosts

### DIFF
--- a/Windows.Kits.cmake
+++ b/Windows.Kits.cmake
@@ -25,7 +25,7 @@
 # | CMake Variable                                      | Description                                                                                                                                       |
 # |-----------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
 # | CMAKE_SYSTEM_VERSION                                | The version of the operating system for which CMake is to build. Defaults to the host version.                                                    |
-# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE         | The architecture of the tooling to use. Defaults to x64.                                                                                          |
+# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE         | The architecture of the tooling to use. Defaults to 'arm64' on ARM64 systems, otherwise 'x64'.                                                    |
 # | CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION            | The version of the Windows SDK to use. Defaults to the highest installed, that is no higher than CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM |
 # | CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM    | The maximum version of the Windows SDK to use, for example '10.0.19041.0'. Defaults to nothing                                                    |
 # | CMAKE_WINDOWS_KITS_10_DIR                           | The location of the root of the Windows Kits 10 directory.                                                                                        |
@@ -51,7 +51,11 @@ if(NOT CMAKE_SYSTEM_VERSION)
 endif()
 
 if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE)
-    set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE x64)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL ARM64)
+        set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE arm64)
+    else()
+        set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE x64)
+    endif()
 endif()
 
 if(NOT CMAKE_WINDOWS_KITS_10_DIR)

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -31,7 +31,7 @@
 # |---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
 # | CMAKE_SYSTEM_PROCESSOR                      | The processor to compiler for. One of 'x86', 'x64'/'AMD64', 'arm', 'arm64'. Defaults to ${CMAKE_HOST_SYSTEM_PROCESSOR}.  |
 # | CMAKE_SYSTEM_VERSION                        | The version of the operating system for which CMake is to build. Defaults to the host version.                           |
-# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE | The architecture of the toolset to use. Defaults to 'x64'.                                                               |
+# | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE | The architecture of the tooling to use. Defaults to 'arm64' on ARM64 systems, otherwise 'x64'.                           |
 # | CMAKE_VS_PRODUCTS                           | One or more Visual Studio Product IDs to consider. Defaults to '*'                                                       |
 # | CMAKE_VS_VERSION_PRERELEASE                 | Whether 'prerelease' versions of Visual Studio should be considered. Defaults to 'OFF'                                   |
 # | CMAKE_VS_VERSION_RANGE                      | A verson range for VS instances to find. For example, '[16.0,17.0)' will find versions '16.*'. Defaults to '[16.0,17.0)' |
@@ -103,7 +103,11 @@ if(NOT CMAKE_VS_PRODUCTS)
 endif()
 
 if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE)
-    set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE x64)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL ARM64)
+        set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE arm64)
+    else()
+        set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE x64)
+    endif()
 endif()
 
 if(NOT VS_USE_SPECTRE_MITIGATION_RUNTIME)


### PR DESCRIPTION
On an ARM64 machine, Visual Studio installs 'host' compilers for arm64, x64 and x86. At the minute, WindowsToolchain defaults to the x64 'host' compilers, since it always defaults to x64 host compilers. But if WindowsToolchain prefers the arm64 host compilers, then there's a decent reduction in compilation and linking times. This PR changes WindowsToolchain to prefer the arm64 host compiler on an ARM64 machine. If consumers want a specific host compiler, the `CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE` variable can be set explicitly.