### PR TITLE
find vs installation of ninja

### DIFF
--- a/Windows.Clang.toolchain.cmake
+++ b/Windows.Clang.toolchain.cmake
@@ -59,7 +59,11 @@ endif()
 
 set(UNUSED ${CMAKE_TOOLCHAIN_FILE}) # Note: only to prevent cmake unused variable warninig
 set(CMAKE_SYSTEM_NAME Windows)
-set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES "CMAKE_SYSTEM_PROCESSOR;CMAKE_CROSSCOMPILING")
+set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
+    CMAKE_SYSTEM_PROCESSOR
+    CMAKE_CLANG_PRODUCTS
+    CMAKE_CROSSCOMPILING
+)
 set(CMAKE_CROSSCOMPILING TRUE)
 set(WIN32 1)
 
@@ -75,6 +79,10 @@ if(NOT CMAKE_VS_VERSION_PRERELEASE)
     set(CMAKE_VS_VERSION_PRERELEASE OFF)
 endif()
 
+if(NOT CMAKE_CLANG_PRODUCTS)
+    set(CMAKE_CLANG_PRODUCTS "*")
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/VSWhere.cmake")
 
 # Find Clang
@@ -82,6 +90,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/VSWhere.cmake")
 findVisualStudio(
     VERSION ${CMAKE_VS_VERSION_RANGE}
     PRERELEASE ${CMAKE_VS_VERSION_PRERELEASE}
+    PRODUCTS ${CMAKE_CLANG_PRODUCTS}
     REQUIRES
         Microsoft.VisualStudio.Component.VC.Llvm.Clang
     PROPERTIES
@@ -169,6 +178,15 @@ find_program(CMAKE_CXX_COMPILER
         "$ENV{ProgramFiles}/LLVM/bin"
     REQUIRED
 )
+
+if(CMAKE_GENERATOR MATCHES "^Ninja")
+    find_program(CMAKE_MAKE_PROGRAM
+        ninja.exe
+    HINTS "${VS_INSTALLATION_PATH}\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\Ninja"
+    REQUIRED
+    )
+    message(VERBOSE "Using ninja.exe: ${CMAKE_MAKE_PROGRAM}")
+endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
     set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} /EHsc")

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -177,6 +177,15 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
     set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} /EHsc")
 endif()
 
+if(CMAKE_GENERATOR MATCHES "^Ninja")
+    find_program(CMAKE_MAKE_PROGRAM
+        ninja.exe
+    HINTS "${VS_INSTALLATION_PATH}\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\Ninja"
+    REQUIRED
+    )
+    message(VERBOSE "Using ninja.exe: ${CMAKE_MAKE_PROGRAM}")
+endif()
+
 # Compiler
 foreach(LANG C CXX RC)
     list(APPEND CMAKE_${LANG}_STANDARD_INCLUDE_DIRECTORIES "${VS_TOOLSET_PATH}/ATLMFC/include")


### PR DESCRIPTION
Fixes https://github.com/MarkSchofield/WindowsToolchain/issues/99

Uses the vs-installation of ninja with `Ninja*` build generators (eg: `Ninja` and `Ninja Multi-Config`).

# Test Plan
* build example projects on my machine -- works with non-core powershell and minor edits to `examples/build.ps1`, but those are outside the scope of this change
* It doesn't seem there are any `Pester` tests contrary to the readme.