### PR TITLE
Add 'Visual Studio 2022' preset configurations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,8 +30,21 @@ jobs:
       max-parallel: 8
       fail-fast: false
       matrix:
-        configuration: [ Debug, Release ]
-        buildPreset: [ windows-msvc-x64, windows-msvc-spectre-x64, windows-msvc-amd64, windows-msvc-x86, windows-msvc-arm64, windows-clang-x64, windows-clang-amd64, windows-clangcl-x64, windows-clangcl-amd64 ]
+        configuration:
+          - Debug
+          - Release
+        buildPreset:
+          - windows-msvc-x64
+          - windows-msvc-spectre-x64
+          - windows-msvc-amd64
+          - windows-msvc-x86
+          - windows-msvc-arm64
+          - windows-clang-x64
+          - windows-clang-amd64
+          - windows-clangcl-x64
+          - windows-clangcl-amd64
+          - windows-vs-x64
+          - windows-vs-arm64
         include:
           - buildPreset: windows-msvc-x64
             cuda: true

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -158,6 +158,37 @@
         "VS_USE_SPECTRE_MITIGATION_RUNTIME": "OFF"
       },
       "binaryDir": "${sourceDir}/__output/${presetName}-$env{VSCMD_ARG_TGT_ARCH}"
+    },
+    {
+      "name": "windows-vs",
+      "inherits": "windows",
+      "hidden": true,
+      "displayName": "Windows-only configuration",
+      "description": "This build is only available on Windows",
+      "generator": "Visual Studio 17 2022",
+      "cacheVariables": {}
+    },
+    {
+      "name": "windows-vs-x64",
+      "inherits": "windows",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/__output/${presetName}",
+      "displayName": "Windows-only configuration",
+      "description": "This build is only available on Windows",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_PROCESSOR": "AMD64"
+      }
+    },
+    {
+      "name": "windows-vs-arm64",
+      "inherits": "windows",
+      "hidden": false,
+      "binaryDir": "${sourceDir}/__output/${presetName}",
+      "displayName": "Windows-only configuration",
+      "description": "This build is only available on Windows",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_PROCESSOR": "ARM64"
+      }
     }
   ],
   "buildPresets": [
@@ -200,6 +231,14 @@
     {
       "name": "ewdk",
       "configurePreset": "ewdk"
+    },
+    {
+      "name": "windows-vs-x64",
+      "configurePreset": "windows-vs-x64"
+    },
+    {
+      "name": "windows-vs-arm64",
+      "configurePreset": "windows-vs-arm64"
     }
   ]
 }


### PR DESCRIPTION
This change adds a ARM64 and X64 'Visual Studio 2022'-generator configurations. I'm hoping that they're useful in ensuring consistency between the 'Visual Studio 2022'-generator and the WindowsToolchain.