### PR TITLE
Fix a few problems in the windows-vs-* presets

### DIFF
--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -145,7 +145,7 @@
       "inherits": "windows-vs",
       "hidden": false,
       "binaryDir": "${sourceDir}/__output/${presetName}",
-      "displayName": "Windows-only configuration",
+      "displayName": "windows-vs-x64",
       "description": "This build is only available on Windows",
       "cacheVariables": {
         "CMAKE_GENERATOR_PLATFORM": "x64,version=10.0.22621.0"
@@ -156,7 +156,7 @@
       "inherits": "windows-vs",
       "hidden": false,
       "binaryDir": "${sourceDir}/__output/${presetName}",
-      "displayName": "Windows-only configuration",
+      "displayName": "windows-vs-arm64",
       "description": "This build is only available on Windows",
       "cacheVariables": {
         "CMAKE_GENERATOR_PLATFORM": "ARM64,version=10.0.22621.0"

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -88,7 +88,7 @@
       "displayName": "Configure for 'windows-msvc-x86'",
       "binaryDir": "${sourceDir}/__output/${presetName}",
       "cacheVariables": {
-        "CMAKE_SYSTEM_PROCESSOR": "x86"
+        "CMAKE_SYSTEM_PROCESSOR": "X86"
       }
     },
     {

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -148,7 +148,7 @@
       "displayName": "Windows-only configuration",
       "description": "This build is only available on Windows",
       "cacheVariables": {
-        "CMAKE_SYSTEM_PROCESSOR": "AMD64"
+        "CMAKE_GENERATOR_PLATFORM": "x64,version=10.0.22621.0"
       }
     },
     {
@@ -159,7 +159,7 @@
       "displayName": "Windows-only configuration",
       "description": "This build is only available on Windows",
       "cacheVariables": {
-        "CMAKE_SYSTEM_PROCESSOR": "ARM64"
+        "CMAKE_GENERATOR_PLATFORM": "ARM64,version=10.0.22621.0"
       }
     }
   ],

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -142,7 +142,7 @@
     },
     {
       "name": "windows-vs-x64",
-      "inherits": "windows",
+      "inherits": "windows-vs",
       "hidden": false,
       "binaryDir": "${sourceDir}/__output/${presetName}",
       "displayName": "Windows-only configuration",
@@ -153,7 +153,7 @@
     },
     {
       "name": "windows-vs-arm64",
-      "inherits": "windows",
+      "inherits": "windows-vs",
       "hidden": false,
       "binaryDir": "${sourceDir}/__output/${presetName}",
       "displayName": "Windows-only configuration",


### PR DESCRIPTION
It turns out that #107 was perhaps a bit rushed. Here's some fixes from trying out the presets:

1. _'windows-vs-*' preset should inherit from 'windows-vs'_ - I typo'd. The 'windows-vs-*' presets should've inherited from 'windows-vs' - just to follow the precedent I've set-up in `CMakePresets.json`. 'windows-vs' was just setting the generator as 'Visual Studio 17 2022', which - it turns out - is the default on Windows, so there's no functional difference here. But being explicit in the generator would be my preference, to make sure that folks don't accidentally pick-up a new one on CMake update.

2. _Set the windows-vs* target architecture using 'CMAKE_GENERATOR_PLATFORM', not 'CMAKE_SYSTEM_PROCESSOR'_ - The Visual Studio Generators expect `CMAKE_GENERATOR_PLATFORM` to set the target processor architecture, not `CMAKE_SYSTEM_PROCESSOR`. Again (since I'm building on x64), the default made me think it was working. The ARM64 build, however, was building for x64, which is broken. The Visual Studio Generators also get told of the Windows SDK through the `CMAKE_GENERATOR_PLATFORM` value, which I hadn't realized. It's a bit awkward - it makes it harder to configure/choose an SDK, but I suppose it's at least clear.

3. _Use CMAKE_SYSTEM_PROCESSOR 'X86', not 'x86'_ I should've cleaned-up my `x86` `CMAKE_SYSTEM_PROCESSOR` value to `X86`. Fixing that now.

4. _Give the windows-vs-* presets better names_ - I've been using VSCode's CMake support a bit more (not just command-line CMake'ing), and the `displayName` of the preset is surfaced prominently, and highlights that the values weren't particularly useful. Fixing that.