### PR TITLE
CUDA only supports x64 compilation; exclude the Cuda example from non-x64 builds

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -24,7 +24,7 @@ add_subdirectory(CommandLineC)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if((CMAKE_CXX_COMPILER_ID STREQUAL "MSVC") AND (CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64))
     if(DEFINED ENV{CUDA_PATH})
         add_subdirectory(CommandLineCuda)
     else()


### PR DESCRIPTION
[The CUDA documentation](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html) calls out that CUDA is only supported with native x64 compilers. Trying an ARM64 build fails. To that end, I'm scoping the 'example' build to only include the CUDA sample when `CMAKE_SYSTEM_PROCESSOR` is `AMD64`.