### PR TITLE
Add an example that builds .asm files

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -9,10 +9,11 @@ endif()
 
 project(WindowsToolchainExample)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    message(STATUS "MSVC_VERSION = ${MSVC_VERSION}")
-    message(STATUS "MSVC_TOOLSET_VERSION = ${MSVC_TOOLSET_VERSION}")
-endif()
+# Write properties that are influenced by the toolchain
+#
+message(STATUS "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "MSVC_VERSION = ${MSVC_VERSION}")
+message(STATUS "MSVC_TOOLSET_VERSION = ${MSVC_TOOLSET_VERSION}")
 
 # Demonstrate that toolchain-related tooling can be found
 #
@@ -30,6 +31,7 @@ add_compile_definitions(
 )
 
 add_subdirectory(CommandLine)
+add_subdirectory(CommandLineAsm)
 add_subdirectory(CommandLineC)
 add_subdirectory(SharedLibrary)
 add_subdirectory(WindowsApplication)

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -138,7 +138,9 @@
       "displayName": "Windows-only configuration",
       "description": "This build is only available on Windows",
       "generator": "Visual Studio 17 2022",
-      "cacheVariables": {}
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "Windows"
+      }
     },
     {
       "name": "windows-vs-x64",
@@ -148,7 +150,8 @@
       "displayName": "windows-vs-x64",
       "description": "This build is only available on Windows",
       "cacheVariables": {
-        "CMAKE_GENERATOR_PLATFORM": "x64,version=10.0.22621.0"
+        "CMAKE_GENERATOR_PLATFORM": "x64,version=10.0.22621.0",
+        "CMAKE_SYSTEM_PROCESSOR": "AMD64"
       }
     },
     {
@@ -159,7 +162,8 @@
       "displayName": "windows-vs-arm64",
       "description": "This build is only available on Windows",
       "cacheVariables": {
-        "CMAKE_GENERATOR_PLATFORM": "ARM64,version=10.0.22621.0"
+        "CMAKE_GENERATOR_PLATFORM": "ARM64,version=10.0.22621.0",
+        "CMAKE_SYSTEM_PROCESSOR": "ARM64"
       }
     }
   ],

--- a/example/CommandLineAsm/CMakeLists.txt
+++ b/example/CommandLineAsm/CMakeLists.txt
@@ -1,0 +1,17 @@
+#----------------------------------------------------------------------------------------------------------------------
+#
+#----------------------------------------------------------------------------------------------------------------------
+project(CommandLineAsm LANGUAGES CXX)
+
+if((CMAKE_SYSTEM_PROCESSOR STREQUAL AMD64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL X86))
+    enable_language(ASM_MASM)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL ARM64)
+    enable_language(ASM_MARMASM)
+else()
+    message(FATAL_ERROR "Unknown CMAKE_SYSTEM_PROCESSOR for ASM language.")
+endif()
+
+add_executable(CommandLineAsm
+    main.cpp
+    helper.${CMAKE_SYSTEM_PROCESSOR}.asm
+)

--- a/example/CommandLineAsm/helper.AMD64.asm
+++ b/example/CommandLineAsm/helper.AMD64.asm
@@ -1,0 +1,11 @@
+INCLUDE macamd64.inc
+
+_TEXT SEGMENT READONLY 'CODE'
+
+LEAF_ENTRY CallAsmCode, _TEXT
+    mov rax, 42
+    ret
+LEAF_END CallAsmCode, _TEXT
+
+_TEXT ENDS
+END

--- a/example/CommandLineAsm/helper.ARM64.asm
+++ b/example/CommandLineAsm/helper.ARM64.asm
@@ -1,0 +1,10 @@
+            AREA .text,CODE,READONLY
+            EXPORT CallAsmCode
+
+            ALIGN
+CallAsmCode FUNCTION
+            mov     lr, 42
+            ret
+            ENDFUNC
+
+            END

--- a/example/CommandLineAsm/helper.X86.asm
+++ b/example/CommandLineAsm/helper.X86.asm
@@ -1,0 +1,14 @@
+INCLUDE callconv.inc
+
+.386
+.MODEL flat
+
+_TEXT SEGMENT READONLY 'CODE'
+
+_CallAsmCode PROC
+    mov eax, DWORD PTR 42
+    ret
+_CallAsmCode ENDP
+
+_TEXT ENDS
+END

--- a/example/CommandLineAsm/main.cpp
+++ b/example/CommandLineAsm/main.cpp
@@ -1,0 +1,28 @@
+//---------------------------------------------------------------------------------------------------------------------
+//
+//---------------------------------------------------------------------------------------------------------------------
+#include <exception>
+#include <iostream>
+
+extern "C"
+{
+    int CallAsmCode();
+}
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    try
+    {
+        try
+        {
+            std::cout << "Value from asm: " << CallAsmCode();
+        }
+        catch (const std::exception& ex)
+        {
+            std::cout << "Exception: " << ex.what();
+        }
+    }
+    catch (...)
+    {
+    }
+}


### PR DESCRIPTION
#117 fixed a bug in `ASM_MASM` usage - the Windows SDK's include paths should be added for the `ASM_MASM` language, so that `.asm` files can correctly find MASM `.inc` files that are shipped in the Windows SDK. This PR adds an 'example', so that it shows that things work, and makes sure that there's no regressions.

This change adds an 'example/CommandLineAsm' folder, with a simple example. A single function - `CallAsmCode` - is implemented in assembly. It takes no parameters, and returns the value `42`. And there's a 'main' that calls the function and prints out the value. I've added implementations for `ASM_MASM` (on X86 and AMD64), and I've added an example for `ASM_MARMASM`, which is used on ARM64. But the ARM64 example is a little broken. The ARM64 include files (for example `kxarm64.h`) contain C-pre-processor directives that the `ASM_MARMASM` assembly doesn't support, because the headers expect the assembly files to have been pre-processed by a C preprocessor first. Looking at the Visual Studio support for MARMASM (in, say, `MSBuild\Microsoft\VC\v170\BuildCustomizations\marmasm.props` and `MSBuild\Microsoft\VC\v170\BuildCustomizations\marmasm.targets`) shows the invocation of the Cl pre-processor first. But with a non-Visual Studio generator, the CMake logic just runs the ARM assembler, without running, say, $(CMAKE_C_COMPILER). I don't know of a way to 'fix' this from a WindowsToolchain level - it seems to be a gap in the CMake support for `ASM_MARMASM`. With all that being said, I could be missing something. Does anyone have any insights that could shed some light here?

Tagging @waldnercharles (who filed #115) and @paulfd (who fixed #115 with #117), in case they have any ideas.