### PR TITLE
Include the VS toolset and Win32 SDK binary paths in the CMAKE_PROGRAM_PATH

### DIFF
--- a/Windows.Clang.toolchain.cmake
+++ b/Windows.Clang.toolchain.cmake
@@ -33,6 +33,7 @@
 # | CMAKE_SYSTEM_PROCESSOR                      | The processor to compiler for. One of 'X86', 'AMD64', 'ARM', 'ARM64'. Defaults to ${CMAKE_HOST_SYSTEM_PROCESSOR}. |
 # | CMAKE_WINDOWS_KITS_10_DIR                   | The location of the root of the Windows Kits 10 directory.                                                      |
 # | CLANG_TIDY_CHECKS                           | List of rules clang-tidy should check. Defaults not set.                                                        |
+# | TOOLCHAIN_UPDATE_PROGRAM_PATH               | Whether the toolchain should update CMAKE_PROGRAM_PATH. Defaults to 'ON'.                                       |
 #
 # The toolchain file will set the following variables:
 #
@@ -57,6 +58,8 @@ if(NOT (CMAKE_HOST_SYSTEM_NAME STREQUAL Windows))
     return()
 endif()
 
+option(TOOLCHAIN_UPDATE_PROGRAM_PATH "Whether the toolchain should update CMAKE_PROGRAM_PATH." ON)
+
 set(UNUSED ${CMAKE_TOOLCHAIN_FILE}) # Note: only to prevent cmake unused variable warninig
 set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES "CMAKE_SYSTEM_PROCESSOR;CMAKE_CROSSCOMPILING")
@@ -76,6 +79,14 @@ if(NOT CMAKE_VS_VERSION_PRERELEASE)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/VSWhere.cmake")
+
+if(NOT CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE)
+    if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL ARM64)
+        set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE arm64)
+    else()
+        set(CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE x64)
+    endif()
+endif()
 
 # Find Clang
 #
@@ -226,3 +237,10 @@ endif()
 
 # Windows Kits
 include("${CMAKE_CURRENT_LIST_DIR}/Windows.Kits.cmake")
+
+# If 'TOOLCHAIN_UPDATE_PROGRAM_PATH' is selected, update CMAKE_PROGRAM_PATH.
+#
+if(TOOLCHAIN_UPDATE_PROGRAM_PATH)
+    list(APPEND CMAKE_PROGRAM_PATH "${VS_TOOLSET_PATH}/bin/Host${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
+    list(APPEND CMAKE_PROGRAM_PATH "${WINDOWS_KITS_BIN_PATH}/${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}")
+endif()

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -29,13 +29,14 @@
 #
 # | CMake Variable                              | Description                                                                                                              |
 # |---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-# | CMAKE_SYSTEM_PROCESSOR                      | The processor to compiler for. One of 'X86', 'AMD64', 'ARM', 'ARM64'. Defaults to ${CMAKE_HOST_SYSTEM_PROCESSOR}.  |
+# | CMAKE_SYSTEM_PROCESSOR                      | The processor to compiler for. One of 'X86', 'AMD64', 'ARM', 'ARM64'. Defaults to ${CMAKE_HOST_SYSTEM_PROCESSOR}.        |
 # | CMAKE_SYSTEM_VERSION                        | The version of the operating system for which CMake is to build. Defaults to the host version.                           |
 # | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE | The architecture of the tooling to use. Defaults to 'arm64' on ARM64 systems, otherwise 'x64'.                           |
 # | CMAKE_VS_PRODUCTS                           | One or more Visual Studio Product IDs to consider. Defaults to '*'                                                       |
 # | CMAKE_VS_VERSION_PRERELEASE                 | Whether 'prerelease' versions of Visual Studio should be considered. Defaults to 'OFF'                                   |
 # | CMAKE_VS_VERSION_RANGE                      | A verson range for VS instances to find. For example, '[16.0,17.0)' will find versions '16.*'. Defaults to '[16.0,17.0)' |
 # | CMAKE_WINDOWS_KITS_10_DIR                   | The location of the root of the Windows Kits 10 directory.                                                               |
+# | TOOLCHAIN_UPDATE_PROGRAM_PATH               | Whether the toolchain should update CMAKE_PROGRAM_PATH. Defaults to 'ON'.                                                |
 # | VS_EXPERIMENTAL_MODULE                      | Whether experimental module support should be enabled.                                                                   |
 # | VS_INSTALLATION_PATH                        | The location of the root of the Visual Studio installation. If not specified VSWhere will be used to search for one.     |
 # | VS_PLATFORM_TOOLSET_VERSION                 | The version of the MSVC toolset to use. For example, 14.29.30133. Defaults to the highest available.                     |
@@ -71,6 +72,8 @@ include_guard()
 if(NOT (CMAKE_HOST_SYSTEM_NAME STREQUAL Windows))
     return()
 endif()
+
+option(TOOLCHAIN_UPDATE_PROGRAM_PATH "Whether the toolchain should update CMAKE_PROGRAM_PATH." ON)
 
 set(UNUSED ${CMAKE_TOOLCHAIN_FILE}) # Note: only to prevent cmake unused variable warninig
 set(CMAKE_SYSTEM_NAME Windows)
@@ -244,4 +247,11 @@ if(CMAKE_CUDA_COMPILER)
     if((NOT CMAKE_CUDA_HOST_COMPILER) AND (NOT DEFINED ENV{CUDAHOSTCXX}))
         set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}")
     endif()
+endif()
+
+# If 'TOOLCHAIN_UPDATE_PROGRAM_PATH' is selected, update CMAKE_PROGRAM_PATH.
+#
+if(TOOLCHAIN_UPDATE_PROGRAM_PATH)
+    list(APPEND CMAKE_PROGRAM_PATH "${VS_TOOLSET_PATH}/bin/Host${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
+    list(APPEND CMAKE_PROGRAM_PATH "${WINDOWS_KITS_BIN_PATH}/${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}")
 endif()

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -14,6 +14,16 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message(STATUS "MSVC_TOOLSET_VERSION = ${MSVC_TOOLSET_VERSION}")
 endif()
 
+# Demonstrate that toolchain-related tooling can be found
+#
+find_program(NMAKE_PATH
+    nmake.exe
+)
+
+message(STATUS "NMAKE_PATH = ${NMAKE_PATH}")
+
+# Build a set of representative projects
+#
 add_compile_definitions(
     UNICODE
     _UNICODE


### PR DESCRIPTION
#114 called out that toolset-related tooling can't be found in CMake using a common CMake idiom - `find_program` relying on `CMAKE_PROGRAM_PATH`. In the case of #114, it was `nmake`, but in investigating #115, it would also be useful in finding MASM - allowing the default CMake logic to find MASM without explicitly setting/managing, say, `CMAKE_ASM_MASM_COMPILER`. This PR adds two paths to `CMAKE_PROGRAM_PATH`:

1. The path to the host- and target- resolved path to the MSVC toolset tools.
  This would allow CMake to find, say, nmake.exe, ml64.exe and armasm64.exe.
2. The path to the Windows SDK binaries.
  This would allow CMake to find, say, mt.exe and signtool.exe.

There's an option to opt-out: setting `TOOLCHAIN_UPDATE_PROGRAM_PATH` to `OFF` will not update `CMAKE_PROGRAM_PATH`. 