### PR TITLE
Consider the Visual Studio path for Ninja

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,10 +49,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Ninja
-        shell: pwsh
-        run: |
-          choco install ninja
       - name: Install NVIDIA Cuda Toolkit
         if: ${{ matrix.cuda }}
         shell: pwsh

--- a/Windows.Clang.toolchain.cmake
+++ b/Windows.Clang.toolchain.cmake
@@ -241,6 +241,13 @@ include("${CMAKE_CURRENT_LIST_DIR}/Windows.Kits.cmake")
 # If 'TOOLCHAIN_UPDATE_PROGRAM_PATH' is selected, update CMAKE_PROGRAM_PATH.
 #
 if(TOOLCHAIN_UPDATE_PROGRAM_PATH)
+    # If the CMAKE_GENERATOR is Ninja-based, and the path to the Visual Studio-installed Ninja is present, add it to
+    # the CMAKE_SYSTEM_PROGRAM_PATH. 'find_program' searches CMAKE_SYSTEM_PROGRAM_PATH after the environment path, so
+    # an installed Ninja would be preferred.
+    if((CMAKE_GENERATOR MATCHES "^Ninja") AND (EXISTS "${VS_INSTALLATION_PATH}/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja"))
+        list(APPEND CMAKE_SYSTEM_PROGRAM_PATH "${VS_INSTALLATION_PATH}/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja")
+    endif()
+
     list(APPEND CMAKE_PROGRAM_PATH "${VS_TOOLSET_PATH}/bin/Host${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
     list(APPEND CMAKE_PROGRAM_PATH "${WINDOWS_KITS_BIN_PATH}/${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}")
 endif()

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -252,6 +252,13 @@ endif()
 # If 'TOOLCHAIN_UPDATE_PROGRAM_PATH' is selected, update CMAKE_PROGRAM_PATH.
 #
 if(TOOLCHAIN_UPDATE_PROGRAM_PATH)
+    # If the CMAKE_GENERATOR is Ninja-based, and the path to the Visual Studio-installed Ninja is present, add it to
+    # the CMAKE_SYSTEM_PROGRAM_PATH. 'find_program' searches CMAKE_SYSTEM_PROGRAM_PATH after the environment path, so
+    # an installed Ninja would be preferred.
+    if((CMAKE_GENERATOR MATCHES "^Ninja") AND (EXISTS "${VS_INSTALLATION_PATH}/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja"))
+        list(APPEND CMAKE_SYSTEM_PROGRAM_PATH "${VS_INSTALLATION_PATH}/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja")
+    endif()
+
     list(APPEND CMAKE_PROGRAM_PATH "${VS_TOOLSET_PATH}/bin/Host${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}/${CMAKE_VS_PLATFORM_TOOLSET_ARCHITECTURE}")
     list(APPEND CMAKE_PROGRAM_PATH "${WINDOWS_KITS_BIN_PATH}/${CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE}")
 endif()


### PR DESCRIPTION
WindowsToolchain used to download Ninja if it was specified as the CMake Generator but wasn't present on the system. That functionality was moved to WindowsCMake (to give WindowsToolchain more focused responsibilities), but #99 called out that the functionality in WindowsCMake didn't consider the Visual Studio installed version of Ninja. The responsibility of the two projects - WindowsToolchain and WindowsCMake made reconciling things difficult; WindowsToolchain is intended to be scoped and minimally sufficient, and only perform 'toolchain'-responsibilities, WindowsCMake runs 'too late' in the CMake configuration to resolve the CMAKE_MAKE_PROGRAM. This PR proposes an alternative fix - WindowsToolchain can add the location of the "Visual Studio"-installed ninja to the CMAKE_SYSTEM_PROGRAM_PATH, which CMake will consider to find the CMAKE_MAKE_PROGRAM. By appending to CMAKE_SYSTEM_PROGRAM_PATH (as opposed to, say, CMAKE_PROGRAM_PATH), the path is considered _after_ the environment path allowing an installed ninja to be preferred.