### PR TITLE
Pass '/X' to ensure that msvc doesn't use include paths from the environment

### DIFF
--- a/Windows.Clang.toolchain.cmake
+++ b/Windows.Clang.toolchain.cmake
@@ -202,6 +202,13 @@ foreach(LANG C CXX RC)
     list(APPEND CMAKE_${LANG}_STANDARD_INCLUDE_DIRECTORIES "${VS_TOOLSET_PATH}/include")
 endforeach()
 
+foreach(LANG C CXX)
+    if(CMAKE_${LANG}_COMPILER_FRONTEND_VARIANT STREQUAL MSVC)
+        # Add '/X': Do not add %INCLUDE% to include search path
+        set(CMAKE_${LANG}_FLAGS_INIT "${CMAKE_${LANG}_FLAGS_INIT} /X")
+    endif()
+endforeach()
+
 if(VS_USE_SPECTRE_MITIGATION_ATLMFC_RUNTIME)
     # Ensure that the necessary folder and files are present before adding the 'link_directories'
     toolchain_validate_vs_files(

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -202,6 +202,11 @@ foreach(LANG C CXX RC)
     list(APPEND CMAKE_${LANG}_STANDARD_INCLUDE_DIRECTORIES "${VS_TOOLSET_PATH}/include")
 endforeach()
 
+foreach(LANG C CXX)
+    # Add '/X': Do not add %INCLUDE% to include search path
+    set(CMAKE_${LANG}_FLAGS_INIT "${CMAKE_${LANG}_FLAGS_INIT} /X")
+endforeach()
+
 if(VS_USE_SPECTRE_MITIGATION_ATLMFC_RUNTIME)
     # Ensure that the necessary folder and files are present before adding the 'link_directories'
     toolchain_validate_vs_files(


### PR DESCRIPTION
Fixes #121.

By default, MSVC will read the 'INCLUDE' environment variable to configure include paths for compilation. WindowsToolchain attempts to push environment variables to CMake constructs to canonicalize the build, so leveraging the '/X' command-line parameter to MSVC - which causes it to ignore the 'INCLUDE' environment variable - would support the effort.