### PR TITLE
CMAKE_CROSSCOMPILING should not be true, if the build targets the host processor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
           - windows-msvc-spectre-x64
           - windows-msvc-x86
           - windows-msvc-arm64
+          - windows-msvc-host
           - windows-clang-x64
           - windows-clangcl-x64
           - windows-vs-x64

--- a/Windows.Clang.toolchain.cmake
+++ b/Windows.Clang.toolchain.cmake
@@ -43,7 +43,7 @@
 # | CMAKE_CXX_COMPILER                          | The path to the C++ compiler to use.                                                                  |
 # | CMAKE_MT                                    | The path to the 'mt.exe' tool to use.                                                                 |
 # | CMAKE_RC_COMPILER                           | The path tp the 'rc.exe' tool to use.                                                                 |
-# | CMAKE_SYSTEM_NAME                           | Windows                                                                                               |
+# | CMAKE_SYSTEM_NAME                           | "Windows", when cross-compiling                                                                       |
 # | WIN32                                       | 1                                                                                                     |
 # | CMAKE_CXX_CLANG_TIDY                        | The commandline clang-tidy is used if CLANG_TIDY_CHECKS was set.                                      |
 #
@@ -54,6 +54,7 @@ cmake_minimum_required(VERSION 3.20)
 
 include_guard()
 
+# If `CMAKE_HOST_SYSTEM_NAME` is not 'Windows', there's nothing to do.
 if(NOT (CMAKE_HOST_SYSTEM_NAME STREQUAL Windows))
     return()
 endif()
@@ -61,13 +62,18 @@ endif()
 option(TOOLCHAIN_UPDATE_PROGRAM_PATH "Whether the toolchain should update CMAKE_PROGRAM_PATH." ON)
 
 set(UNUSED ${CMAKE_TOOLCHAIN_FILE}) # Note: only to prevent cmake unused variable warninig
-set(CMAKE_SYSTEM_NAME Windows)
-set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES "CMAKE_SYSTEM_PROCESSOR;CMAKE_CROSSCOMPILING")
-set(CMAKE_CROSSCOMPILING TRUE)
+set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES "CMAKE_SYSTEM_PROCESSOR")
 set(WIN32 1)
 
+# If `CMAKE_SYSTEM_PROCESSOR` isn't set, default to `CMAKE_HOST_SYSTEM_PROCESSOR`
 if(NOT CMAKE_SYSTEM_PROCESSOR)
     set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+
+# If `CMAKE_SYSTEM_PROCESSOR` is not equal to `CMAKE_HOST_SYSTEM_PROCESSOR`, this is cross-compilation.
+# CMake expects `CMAKE_SYSTEM_NAME` to be set to reflect cross-compilation.
+if(NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR}))
+    set(CMAKE_SYSTEM_NAME Windows)
 endif()
 
 if(NOT CMAKE_VS_VERSION_RANGE)

--- a/Windows.EWDK.toolchain.cmake
+++ b/Windows.EWDK.toolchain.cmake
@@ -52,7 +52,7 @@
 # | CMAKE_CXX_COMPILER                          | The path to the C++ compiler to use.                                                                  |
 # | CMAKE_MT                                    | The path to the 'mt.exe' tool to use.                                                                 |
 # | CMAKE_RC_COMPILER                           | The path tp the 'rc.exe' tool to use.                                                                 |
-# | CMAKE_SYSTEM_NAME                           | 'Windows'                                                                                             |
+# | CMAKE_SYSTEM_NAME                           | "Windows", when cross-compiling                                                                       |
 # | CMAKE_SYSTEM_PROCESSOR                      | The architecture to build for (e.g. ARM64).                                                           |
 # | CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE | The architecture of the host tooling to use (e.g. x86).                                               |
 # | CMAKE_VS_PLATFORM_TOOLSET_VERSION           | The version of the MSVC platform toolset to use (e.g. 14.31.31103).                                   |

--- a/Windows.MSVC.toolchain.cmake
+++ b/Windows.MSVC.toolchain.cmake
@@ -51,7 +51,7 @@
 # | CMAKE_CXX_COMPILER                          | The path to the C++ compiler to use.                                                                  |
 # | CMAKE_MT                                    | The path to the 'mt.exe' tool to use.                                                                 |
 # | CMAKE_RC_COMPILER                           | The path tp the 'rc.exe' tool to use.                                                                 |
-# | CMAKE_SYSTEM_NAME                           | Windows                                                                                               |
+# | CMAKE_SYSTEM_NAME                           | "Windows", when cross-compiling                                                                       |
 # | CMAKE_VS_PLATFORM_TOOLSET_VERSION           | The version of the MSVC toolset being used - e.g. 14.29.30133.                                        |
 # | WIN32                                       | 1                                                                                                     |
 # | MSVC                                        | 1                                                                                                     |
@@ -69,6 +69,7 @@ cmake_minimum_required(VERSION 3.20)
 
 include_guard()
 
+# If `CMAKE_HOST_SYSTEM_NAME` is not 'Windows', there's nothing to do.
 if(NOT (CMAKE_HOST_SYSTEM_NAME STREQUAL Windows))
     return()
 endif()
@@ -76,9 +77,7 @@ endif()
 option(TOOLCHAIN_UPDATE_PROGRAM_PATH "Whether the toolchain should update CMAKE_PROGRAM_PATH." ON)
 
 set(UNUSED ${CMAKE_TOOLCHAIN_FILE}) # Note: only to prevent cmake unused variable warninig
-set(CMAKE_SYSTEM_NAME Windows)
 set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
-    CMAKE_CROSSCOMPILING
     CMAKE_SYSTEM_PROCESSOR
     CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE
     CMAKE_VS_PRODUCTS
@@ -88,14 +87,20 @@ set(CMAKE_TRY_COMPILE_PLATFORM_VARIABLES
     VS_INSTALLATION_VERSION
     VS_PLATFORM_TOOLSET_VERSION
 )
-set(CMAKE_CROSSCOMPILING TRUE)
 set(WIN32 1)
 set(MSVC 1)
 
 include("${CMAKE_CURRENT_LIST_DIR}/VSWhere.cmake")
 
+# If `CMAKE_SYSTEM_PROCESSOR` isn't set, default to `CMAKE_HOST_SYSTEM_PROCESSOR`
 if(NOT CMAKE_SYSTEM_PROCESSOR)
     set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif()
+
+# If `CMAKE_SYSTEM_PROCESSOR` is not equal to `CMAKE_HOST_SYSTEM_PROCESSOR`, this is cross-compilation.
+# CMake expects `CMAKE_SYSTEM_NAME` to be set to reflect cross-compilation.
+if(NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL ${CMAKE_HOST_SYSTEM_PROCESSOR}))
+    set(CMAKE_SYSTEM_NAME Windows)
 endif()
 
 if(NOT CMAKE_VS_VERSION_RANGE)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,9 +11,11 @@ project(WindowsToolchainExample)
 
 # Write properties that are influenced by the toolchain
 #
+message(STATUS "CMAKE_CROSSCOMPILING = ${CMAKE_CROSSCOMPILING}")
+message(STATUS "CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
 message(STATUS "CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
-message(STATUS "MSVC_VERSION = ${MSVC_VERSION}")
 message(STATUS "MSVC_TOOLSET_VERSION = ${MSVC_TOOLSET_VERSION}")
+message(STATUS "MSVC_VERSION = ${MSVC_VERSION}")
 
 # Demonstrate that toolchain-related tooling can be found
 #

--- a/example/CMakePresets.json
+++ b/example/CMakePresets.json
@@ -101,6 +101,12 @@
       }
     },
     {
+      "name": "windows-msvc-host",
+      "inherits": "windows-msvc",
+      "displayName": "Configure for 'windows-msvc-host'",
+      "binaryDir": "${sourceDir}/__output/${presetName}"
+    },
+    {
       "name": "windows-clang-x64",
       "inherits": "windows-clang",
       "displayName": "Configure for 'windows-clang-x64'",
@@ -183,6 +189,10 @@
     {
       "name": "windows-msvc-arm64",
       "configurePreset": "windows-msvc-arm64"
+    },
+    {
+      "name": "windows-msvc-host",
+      "configurePreset": "windows-msvc-host"
     },
     {
       "name": "windows-clang-x64",


### PR DESCRIPTION
Fixes #123.

#105 discusses when `CMAKE_CROSSCOMPILING` should be set and cites the CMake documentation around `CMAKE_CROSSCOMPILING`. The crux - I think - comes down to [the logic in `Modules/CMakeDetermineSystem.cmake`](https://github.com/Kitware/CMake/blob/b346afce4fc977d875c613334ebb5365cd647453/Modules/CMakeDetermineSystem.cmake#L156C1-L182C8), where CMake sets `CMAKE_CROSSCOMPILING` itself, based on whether `CMAKE_SYSTEM_NAME` is set.

With this change, the toolchains no longer set `CMAKE_CROSSCOMPILING` at all and instead rely on the CMake logic. The toolchains will only set `CMAKE_SYSTEM_NAME` if `CMAKE_SYSTEM_PROCESSOR` is different to `CMAKE_SYSTEM_PROCESSOR`. And setting `CMAKE_SYSTEM_NAME` causes the CMake logic to configure `CMAKE_CROSSCOMPILING`. If `CMAKE_SYSTEM_NAME` _isn't_ set by the toolchain, CMake will default it to the `CMAKE_HOST_SYSTEM_NAME`.

I've added a preset (`windows-msvc-host`) to `example/CMakePresets.json` that doesn't specify `CMAKE_SYSTEM_PROCESSOR` and that should always result in `CMAKE_CROSSCOMPILING = FALSE`. And building the preset that is the same system processor as the host will result in `CMAKE_CROSSCOMPILING = FALSE`. All other cases should be `CMAKE_CROSSCOMPILING = TRUE`.